### PR TITLE
Migrate to Swift 3 & Xcode 8

### DIFF
--- a/DrawerController.xcodeproj/project.pbxproj
+++ b/DrawerController.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 				TargetAttributes = {
 					FAEF01351AFEE4FF00DFDF7F = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -267,6 +268,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -285,6 +287,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.evolved.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/DrawerController.xcodeproj/project.pbxproj
+++ b/DrawerController.xcodeproj/project.pbxproj
@@ -111,7 +111,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = evolved.io;
 				TargetAttributes = {
 					FAEF01351AFEE4FF00DFDF7F = {
@@ -287,6 +287,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "io.evolved.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;

--- a/DrawerController.xcodeproj/xcshareddata/xcschemes/DrawerController.xcscheme
+++ b/DrawerController.xcodeproj/xcshareddata/xcschemes/DrawerController.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -66,11 +66,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -88,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/DrawerController/AnimatedMenuButton.swift
+++ b/DrawerController/AnimatedMenuButton.swift
@@ -34,21 +34,21 @@ public class AnimatedMenuButton : UIButton {
     let animationDuration: CFTimeInterval = 8.0
     
     let shortStroke: CGPath = {
-        let path = CGPathCreateMutable()
-        CGPathMoveToPoint(path, nil, 2, 2)
-        CGPathAddLineToPoint(path, nil, 30 - 2 * 2, 2)
+        let path = CGMutablePath()
+        path.moveTo(nil, x: 2, y: 2)
+        path.addLineTo(nil, x: 30 - 2 * 2, y: 2)
         return path
         }()
     
     // MARK: - Initializers
     
     required public init?(coder aDecoder: NSCoder) {
-        self.strokeColor = UIColor.grayColor()
+        self.strokeColor = UIColor.gray()
         super.init(coder: aDecoder)
     }
 
     override convenience init(frame: CGRect) {
-        self.init(frame: frame, strokeColor: UIColor.grayColor())
+        self.init(frame: frame, strokeColor: UIColor.gray())
     }
     
     init(frame: CGRect, strokeColor: UIColor) {
@@ -61,15 +61,15 @@ public class AnimatedMenuButton : UIButton {
         
         for layer in [ self.top, self.middle, self.bottom ] {
             layer.fillColor = nil
-            layer.strokeColor = self.strokeColor.CGColor
+            layer.strokeColor = self.strokeColor.cgColor
             layer.lineWidth = 4
             layer.miterLimit = 2
             layer.lineCap = kCALineCapRound
             layer.masksToBounds = true
             
-            let strokingPath = CGPathCreateCopyByStrokingPath(layer.path, nil, 4, .Round, .Miter, 4)
+            let strokingPath = CGPath(copyByStroking: layer.path!, transform: nil, lineWidth: 4, lineCap: .round, lineJoin: .miter, miterLimit: 4)
             
-            layer.bounds = CGPathGetPathBoundingBox(strokingPath)
+            layer.bounds = (strokingPath?.boundingBoxOfPath)!
             
             layer.actions = [
                 "opacity": NSNull(),
@@ -89,16 +89,16 @@ public class AnimatedMenuButton : UIButton {
     
     // MARK: - Animations
     
-    public func animateWithPercentVisible(percentVisible:CGFloat, drawerSide: DrawerSide) {
+    public func animateWithPercentVisible(_ percentVisible:CGFloat, drawerSide: DrawerSide) {
         
-        if drawerSide == DrawerSide.Left {
+        if drawerSide == DrawerSide.left {
             self.top.anchorPoint = CGPoint(x: 1, y: 0.5)
             self.top.position = CGPoint(x: 30 - 1, y: 5)
             self.middle.position = CGPoint(x: 15, y: 15)
             
             self.bottom.anchorPoint = CGPoint(x: 1, y: 0.5)
             self.bottom.position = CGPoint(x: 30 - 1, y: 25)
-        } else if drawerSide == DrawerSide.Right {
+        } else if drawerSide == DrawerSide.right {
             self.top.anchorPoint = CGPoint(x: 0, y: 0.5)
             self.top.position = CGPoint(x: 1, y: 5)
             self.middle.position = CGPoint(x: 15, y: 15)
@@ -121,16 +121,16 @@ public class AnimatedMenuButton : UIButton {
         
         let translation = CATransform3DMakeTranslation(-4 * percentVisible, 0, 0)
         
-        let sideInverter: CGFloat = drawerSide == DrawerSide.Left ? -1 : 1
-        topTransform.toValue = NSValue(CATransform3D: CATransform3DRotate(translation, 1.0 * sideInverter * ((CGFloat)(45.0 * M_PI / 180.0) * percentVisible), 0, 0, 1))
-        bottomTransform.toValue = NSValue(CATransform3D: CATransform3DRotate(translation, (-1.0 * sideInverter * (CGFloat)(45.0 * M_PI / 180.0) * percentVisible), 0, 0, 1))
+        let sideInverter: CGFloat = drawerSide == DrawerSide.left ? -1 : 1
+        topTransform.toValue = NSValue(caTransform3D: CATransform3DRotate(translation, 1.0 * sideInverter * ((CGFloat)(45.0 * M_PI / 180.0) * percentVisible), 0, 0, 1))
+        bottomTransform.toValue = NSValue(caTransform3D: CATransform3DRotate(translation, (-1.0 * sideInverter * (CGFloat)(45.0 * M_PI / 180.0) * percentVisible), 0, 0, 1))
 
         topTransform.beginTime = CACurrentMediaTime()
         bottomTransform.beginTime = CACurrentMediaTime()
         
-        self.top.addAnimation(topTransform, forKey: topTransform.keyPath)
-        self.middle.addAnimation(middleTransform, forKey: middleTransform.keyPath)
-        self.bottom.addAnimation(bottomTransform, forKey: bottomTransform.keyPath)
+        self.top.add(topTransform, forKey: topTransform.keyPath)
+        self.middle.add(middleTransform, forKey: middleTransform.keyPath)
+        self.bottom.add(bottomTransform, forKey: bottomTransform.keyPath)
         
         self.top.setValue(topTransform.toValue, forKey: topTransform.keyPath!)
         self.middle.setValue(middleTransform.toValue, forKey: middleTransform.keyPath!)

--- a/DrawerController/DrawerBarButtonItem.swift
+++ b/DrawerController/DrawerBarButtonItem.swift
@@ -34,12 +34,12 @@ public class DrawerBarButtonItem: UIBarButtonItem {
     }
 
     public convenience init(target: AnyObject?, action: Selector) {
-        self.init(target: target, action: action, menuIconColor: UIColor.grayColor())
+        self.init(target: target, action: action, menuIconColor: UIColor.gray())
     }
 
     public convenience init(target: AnyObject?, action: Selector, menuIconColor: UIColor) {
         let menuButton = AnimatedMenuButton(frame: CGRect(x: 0, y: 0, width: 30, height: 30), strokeColor: menuIconColor)
-        menuButton.addTarget(target, action: action, forControlEvents: UIControlEvents.TouchUpInside)
+        menuButton.addTarget(target, action: action, for: UIControlEvents.touchUpInside)
         self.init(customView: menuButton)
         
         self.menuButton = menuButton
@@ -53,7 +53,7 @@ public class DrawerBarButtonItem: UIBarButtonItem {
     
     // MARK: - Animations
     
-    public func animateWithPercentVisible(percentVisible: CGFloat, drawerSide: DrawerSide) {
+    public func animateWithPercentVisible(_ percentVisible: CGFloat, drawerSide: DrawerSide) {
         if let btn = self.customView as? AnimatedMenuButton {
             btn.animateWithPercentVisible(percentVisible, drawerSide: drawerSide)
         }

--- a/DrawerController/DrawerController.swift
+++ b/DrawerController/DrawerController.swift
@@ -22,14 +22,14 @@ import UIKit
 
 public extension UIViewController {
     var evo_drawerController: DrawerController? {
-        var parentViewController = self.parentViewController
+        var parentViewController = self.parent
         
         while parentViewController != nil {
-            if parentViewController!.isKindOfClass(DrawerController) {
+            if parentViewController!.isKind(of: DrawerController.self) {
                 return parentViewController as? DrawerController
             }
             
-            parentViewController = parentViewController!.parentViewController
+            parentViewController = parentViewController!.parent
         }
         
         return nil
@@ -49,21 +49,21 @@ public extension UIViewController {
                 if self == drawerController.rightDrawerViewController || self.navigationController == drawerController.rightDrawerViewController {
                     var rect = drawerController.view.bounds
                     rect.size.width = drawerController.maximumRightDrawerWidth
-                    rect.origin.x = CGRectGetWidth(drawerController.view.bounds) - rect.size.width
+                    rect.origin.x = drawerController.view.bounds.width - rect.size.width
                     return rect
                 }
             }
         }
         
-        return CGRectNull
+        return CGRect.null
     }
 }
 
-private func bounceKeyFrameAnimationForDistanceOnView(distance: CGFloat, view: UIView) -> CAKeyframeAnimation {
+private func bounceKeyFrameAnimationForDistanceOnView(_ distance: CGFloat, view: UIView) -> CAKeyframeAnimation {
     let factors: [CGFloat] = [0, 32, 60, 83, 100, 114, 124, 128, 128, 124, 114, 100, 83, 60, 32, 0, 24, 42, 54, 62, 64, 62, 54, 42, 24, 0, 18, 28, 32, 28, 18, 0]
     
     let values = factors.map({ x in
-        NSNumber(float: Float(x / 128 * distance + CGRectGetMidX(view.bounds)))
+        NSNumber(value: Float(x / 128 * distance + view.bounds.midX))
     })
     
     let animation = CAKeyframeAnimation(keyPath: "position.x")
@@ -71,19 +71,19 @@ private func bounceKeyFrameAnimationForDistanceOnView(distance: CGFloat, view: U
     animation.duration = 0.8
     animation.fillMode = kCAFillModeForwards
     animation.values = values
-    animation.removedOnCompletion = true
+    animation.isRemovedOnCompletion = true
     animation.autoreverses = false
     
     return animation
 }
 
 public enum DrawerSide: Int {
-    case None
-    case Left
-    case Right
+    case none
+    case left
+    case right
 }
 
-public struct OpenDrawerGestureMode: OptionSetType {
+public struct OpenDrawerGestureMode: OptionSet {
     public let rawValue: UInt
     public init(rawValue: UInt) { self.rawValue = rawValue }
     
@@ -94,7 +94,7 @@ public struct OpenDrawerGestureMode: OptionSetType {
     public static let All: OpenDrawerGestureMode = [PanningNavigationBar, PanningCenterView, BezelPanningCenterView, Custom]
 }
 
-public struct CloseDrawerGestureMode: OptionSetType {
+public struct CloseDrawerGestureMode: OptionSet {
     public let rawValue: UInt
     public init(rawValue: UInt) { self.rawValue = rawValue }
     
@@ -109,15 +109,15 @@ public struct CloseDrawerGestureMode: OptionSetType {
 }
 
 public enum DrawerOpenCenterInteractionMode: Int {
-    case None
-    case Full
-    case NavigationBarOnly
+    case none
+    case full
+    case navigationBarOnly
 }
 
 private let DrawerDefaultWidth: CGFloat = 280.0
 private let DrawerDefaultAnimationVelocity: CGFloat = 840.0
 
-private let DrawerDefaultFullAnimationDelay: NSTimeInterval = 0.10
+private let DrawerDefaultFullAnimationDelay: TimeInterval = 0.10
 
 private let DrawerDefaultBounceDistance: CGFloat = 50.0
 
@@ -146,18 +146,18 @@ public typealias DrawerGestureCompletionBlock = (DrawerController, UIGestureReco
 public typealias DrawerControllerDrawerVisualStateBlock = (DrawerController, DrawerSide, CGFloat) -> Void
 
 private class DrawerCenterContainerView: UIView {
-    private var openSide: DrawerSide = .None
-    var centerInteractionMode: DrawerOpenCenterInteractionMode = .None
+    private var openSide: DrawerSide = .none
+    var centerInteractionMode: DrawerOpenCenterInteractionMode = .none
     
-    private override func hitTest(point: CGPoint, withEvent event: UIEvent?) -> UIView? {
-        var hitView = super.hitTest(point, withEvent: event)
+    private override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        var hitView = super.hitTest(point, with: event)
         
-        if hitView != nil && self.openSide != .None {
+        if hitView != nil && self.openSide != .none {
             let navBar = self.navigationBarContainedWithinSubviewsOfView(self)
             
             if navBar != nil {
-                let navBarFrame = navBar!.convertRect(navBar!.bounds, toView: self)
-                if (self.centerInteractionMode == .NavigationBarOnly && CGRectContainsPoint(navBarFrame, point) == false) || (self.centerInteractionMode == .None) {
+                let navBarFrame = navBar!.convert(navBar!.bounds, to: self)
+                if (self.centerInteractionMode == .navigationBarOnly && navBarFrame.contains(point) == false) || (self.centerInteractionMode == .none) {
                     hitView = nil
                 }
             }
@@ -166,11 +166,11 @@ private class DrawerCenterContainerView: UIView {
         return hitView
     }
     
-    private func navigationBarContainedWithinSubviewsOfView(view: UIView) -> UINavigationBar? {
+    private func navigationBarContainedWithinSubviewsOfView(_ view: UIView) -> UINavigationBar? {
         var navBar: UINavigationBar?
         
         for subview in view.subviews as [UIView] {
-            if view.isKindOfClass(UINavigationBar) {
+            if view.isKind(of: UINavigationBar.self) {
                 navBar = view as? UINavigationBar
                 break
             } else {
@@ -218,7 +218,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
         }
         
         set {
-            self.setDrawerViewController(newValue, forSide: .Left)
+            self.setDrawerViewController(newValue, forSide: .left)
         }
     }
     
@@ -233,7 +233,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
         }
         
         set {
-            self.setDrawerViewController(newValue, forSide: .Right)
+            self.setDrawerViewController(newValue, forSide: .right)
         }
     }
     
@@ -283,7 +283,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     */
     public var visibleLeftDrawerWidth: CGFloat {
         get {
-            return max(0.0, CGRectGetMinX(self.centerContainerView.frame))
+            return max(0.0, self.centerContainerView.frame.minX)
         }
     }
     
@@ -294,8 +294,8 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     */
     public var visibleRightDrawerWidth: CGFloat {
         get {
-            if CGRectGetMinX(self.centerContainerView.frame) < 0 {
-                return CGRectGetWidth(self.childControllerContainerView.bounds) - CGRectGetMaxX(self.centerContainerView.frame)
+            if self.centerContainerView.frame.minX < 0 {
+                return self.childControllerContainerView.bounds.width - self.centerContainerView.frame.maxX
             } else {
                 return 0.0
             }
@@ -327,15 +327,15 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     public var animationVelocity = DrawerDefaultAnimationVelocity
     private var animatingDrawer: Bool = false {
         didSet {
-            self.view.userInteractionEnabled = !self.animatingDrawer
+            self.view.isUserInteractionEnabled = !self.animatingDrawer
         }
     }
     
     private lazy var childControllerContainerView: UIView = {
         let childContainerViewFrame = self.view.bounds
         let childControllerContainerView = UIView(frame: childContainerViewFrame)
-        childControllerContainerView.backgroundColor = UIColor.clearColor()
-        childControllerContainerView.autoresizingMask = [.FlexibleHeight, .FlexibleWidth]
+        childControllerContainerView.backgroundColor = UIColor.clear()
+        childControllerContainerView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         self.view.addSubview(childControllerContainerView)
         
         return childControllerContainerView
@@ -345,8 +345,8 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
         let centerFrame = self.childControllerContainerView.bounds
         
         let centerContainerView = DrawerCenterContainerView(frame: centerFrame)
-        centerContainerView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
-        centerContainerView.backgroundColor = UIColor.clearColor()
+        centerContainerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        centerContainerView.backgroundColor = UIColor.clear()
         centerContainerView.openSide = self.openSide
         centerContainerView.centerInteractionMode = self.centerHiddenInteractionMode
         self.childControllerContainerView.addSubview(centerContainerView)
@@ -359,19 +359,19 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     
     Note this value will change as soon as a pan gesture opens a drawer, or when a open/close animation is finished.
     */
-    public private(set) var openSide: DrawerSide = .None {
+    public private(set) var openSide: DrawerSide = .none {
         didSet {
             self.centerContainerView.openSide = self.openSide
-            if self.openSide == .None {
-                self.leftDrawerViewController?.view.hidden = true
-                self.rightDrawerViewController?.view.hidden = true
+            if self.openSide == .none {
+                self.leftDrawerViewController?.view.isHidden = true
+                self.rightDrawerViewController?.view.isHidden = true
             }
             
             self.setNeedsStatusBarAppearanceUpdate()
         }
     }
     
-    private var startingPanRect: CGRect = CGRectNull
+    private var startingPanRect: CGRect = CGRect.null
     
     /**
     Sets a callback to be called when a gesture has been completed.
@@ -427,7 +427,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     
     By default, it is `DrawerOpenCenterInteractionModeNavigationBarOnly`, meaning that the user can only interact with the buttons on the `UINavigationBar`, if the center view controller is a `UINavigationController`. Otherwise, the user cannot interact with any other center view controller elements.
     */
-    public var centerHiddenInteractionMode: DrawerOpenCenterInteractionMode = .NavigationBarOnly {
+    public var centerHiddenInteractionMode: DrawerOpenCenterInteractionMode = .navigationBarOnly {
         didSet {
             self.centerContainerView.centerInteractionMode = self.centerHiddenInteractionMode
         }
@@ -439,7 +439,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
         super.init(coder: aDecoder)
     }
     
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
     
@@ -486,40 +486,40 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     
     // MARK: - State Restoration
     
-    public override func encodeRestorableStateWithCoder(coder: NSCoder) {
-        super.encodeRestorableStateWithCoder(coder)
+    public override func encodeRestorableState(with coder: NSCoder) {
+        super.encodeRestorableState(with: coder)
         
         if let leftDrawerViewController = self.leftDrawerViewController {
-            coder.encodeObject(leftDrawerViewController, forKey: DrawerLeftDrawerKey)
+            coder.encode(leftDrawerViewController, forKey: DrawerLeftDrawerKey)
         }
         
         if let rightDrawerViewController = self.rightDrawerViewController {
-            coder.encodeObject(rightDrawerViewController, forKey: DrawerRightDrawerKey)
+            coder.encode(rightDrawerViewController, forKey: DrawerRightDrawerKey)
         }
         
         if let centerViewController = self.centerViewController {
-            coder.encodeObject(centerViewController, forKey: DrawerCenterKey)
+            coder.encode(centerViewController, forKey: DrawerCenterKey)
         }
         
-        coder.encodeInteger(self.openSide.rawValue, forKey: DrawerOpenSideKey)
+        coder.encode(self.openSide.rawValue, forKey: DrawerOpenSideKey)
     }
     
-    public override func decodeRestorableStateWithCoder(coder: NSCoder) {
-        super.decodeRestorableStateWithCoder(coder)
+    public override func decodeRestorableState(with coder: NSCoder) {
+        super.decodeRestorableState(with: coder)
         
-        if let leftDrawerViewController: AnyObject = coder.decodeObjectForKey(DrawerLeftDrawerKey) {
+        if let leftDrawerViewController: AnyObject = coder.decodeObject(forKey: DrawerLeftDrawerKey) {
             self.leftDrawerViewController = leftDrawerViewController as? UIViewController
         }
         
-        if let rightDrawerViewController: AnyObject = coder.decodeObjectForKey(DrawerRightDrawerKey) {
+        if let rightDrawerViewController: AnyObject = coder.decodeObject(forKey: DrawerRightDrawerKey) {
             self.rightDrawerViewController = rightDrawerViewController as? UIViewController
         }
         
-        if let centerViewController: AnyObject = coder.decodeObjectForKey(DrawerCenterKey) {
+        if let centerViewController: AnyObject = coder.decodeObject(forKey: DrawerCenterKey) {
             self.centerViewController = centerViewController as? UIViewController
         }
         
-        if let openSide = DrawerSide(rawValue: coder.decodeIntegerForKey(DrawerOpenSideKey)) {
+        if let openSide = DrawerSide(rawValue: coder.decodeInteger(forKey: DrawerOpenSideKey)) {
             self.openSide = openSide
         }
     }
@@ -536,41 +536,41 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     
     // MARK: - Animation helpers
     
-    private func finishAnimationForPanGestureWithXVelocity(xVelocity: CGFloat, completion: ((Bool) -> Void)?) {
-        var currentOriginX = CGRectGetMinX(self.centerContainerView.frame)
+    private func finishAnimationForPanGestureWithXVelocity(_ xVelocity: CGFloat, completion: ((Bool) -> Void)?) {
+        var currentOriginX = self.centerContainerView.frame.minX
         let animationVelocity = max(abs(xVelocity), DrawerPanVelocityXAnimationThreshold * 2)
         
-        if self.openSide == .Left {
+        if self.openSide == .left {
             let midPoint = self.maximumLeftDrawerWidth / 2.0
             
             if xVelocity > DrawerPanVelocityXAnimationThreshold {
-                self.openDrawerSide(.Left, animated: true, velocity: animationVelocity, animationOptions: [], completion: completion)
+                self.openDrawerSide(.left, animated: true, velocity: animationVelocity, animationOptions: [], completion: completion)
             } else if xVelocity < -DrawerPanVelocityXAnimationThreshold {
                 self.closeDrawerAnimated(true, velocity: animationVelocity, animationOptions: [], completion: completion)
             } else if currentOriginX < midPoint {
                 self.closeDrawerAnimated(true, completion: completion)
             } else {
-                self.openDrawerSide(.Left, animated: true, completion: completion)
+                self.openDrawerSide(.left, animated: true, completion: completion)
             }
-        } else if self.openSide == .Right {
-            currentOriginX = CGRectGetMaxX(self.centerContainerView.frame)
-            let midPoint = (CGRectGetWidth(self.childControllerContainerView.bounds) - self.maximumRightDrawerWidth) + (self.maximumRightDrawerWidth / 2.0)
+        } else if self.openSide == .right {
+            currentOriginX = self.centerContainerView.frame.maxX
+            let midPoint = (self.childControllerContainerView.bounds.width - self.maximumRightDrawerWidth) + (self.maximumRightDrawerWidth / 2.0)
             
             if xVelocity > DrawerPanVelocityXAnimationThreshold {
                 self.closeDrawerAnimated(true, velocity: animationVelocity, animationOptions: [], completion: completion)
             } else if xVelocity < -DrawerPanVelocityXAnimationThreshold {
-                self.openDrawerSide(.Right, animated: true, velocity: animationVelocity, animationOptions: [], completion: completion)
+                self.openDrawerSide(.right, animated: true, velocity: animationVelocity, animationOptions: [], completion: completion)
             } else if currentOriginX > midPoint {
                 self.closeDrawerAnimated(true, completion: completion)
             } else {
-                self.openDrawerSide(.Right, animated: true, completion: completion)
+                self.openDrawerSide(.right, animated: true, completion: completion)
             }
         } else {
             completion?(false)
         }
     }
     
-    private func updateDrawerVisualStateForDrawerSide(drawerSide: DrawerSide, percentVisible: CGFloat) {
+    private func updateDrawerVisualStateForDrawerSide(_ drawerSide: DrawerSide, percentVisible: CGFloat) {
         if let drawerVisualState = self.drawerVisualStateBlock {
             drawerVisualState(self, drawerSide, percentVisible)
         } else if self.shouldStretchDrawer {
@@ -578,15 +578,15 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
         }
     }
     
-    private func applyOvershootScaleTransformForDrawerSide(drawerSide: DrawerSide, percentVisible: CGFloat) {
+    private func applyOvershootScaleTransformForDrawerSide(_ drawerSide: DrawerSide, percentVisible: CGFloat) {
         if percentVisible >= 1.0 {
             var transform = CATransform3DIdentity
             
             if let sideDrawerViewController = self.sideDrawerViewControllerForSide(drawerSide) {
-                if drawerSide == .Left {
+                if drawerSide == .left {
                     transform = CATransform3DMakeScale(percentVisible, 1.0, 1.0)
                     transform = CATransform3DTranslate(transform, self._maximumLeftDrawerWidth * (percentVisible - 1.0) / 2, 0, 0)
-                } else if drawerSide == .Right {
+                } else if drawerSide == .right {
                     transform = CATransform3DMakeScale(percentVisible, 1.0, 1.0)
                     transform = CATransform3DTranslate(transform, -self._maximumRightDrawerWidth * (percentVisible - 1.0) / 2, 0, 0)
                 }
@@ -596,7 +596,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
         }
     }
     
-    private func resetDrawerVisualStateForDrawerSide(drawerSide: DrawerSide) {
+    private func resetDrawerVisualStateForDrawerSide(_ drawerSide: DrawerSide) {
         if let sideDrawerViewController = self.sideDrawerViewControllerForSide(drawerSide) {
             sideDrawerViewController.view.layer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
             sideDrawerViewController.view.layer.transform = CATransform3DIdentity
@@ -604,17 +604,17 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
         }
     }
     
-    private func roundedOriginXForDrawerConstraints(originX: CGFloat) -> CGFloat {
+    private func roundedOriginXForDrawerConstraints(_ originX: CGFloat) -> CGFloat {
         if originX < -self.maximumRightDrawerWidth {
             if self.shouldStretchDrawer && self.rightDrawerViewController != nil {
-                let maxOvershoot: CGFloat = (CGRectGetWidth(self.centerContainerView.frame) - self.maximumRightDrawerWidth) * DrawerOvershootPercentage
+                let maxOvershoot: CGFloat = (self.centerContainerView.frame.width - self.maximumRightDrawerWidth) * DrawerOvershootPercentage
                 return self.originXForDrawerOriginAndTargetOriginOffset(originX, targetOffset: -self.maximumRightDrawerWidth, maxOvershoot: maxOvershoot)
             } else {
                 return -self.maximumRightDrawerWidth
             }
         } else if originX > self.maximumLeftDrawerWidth {
             if self.shouldStretchDrawer && self.leftDrawerViewController != nil {
-                let maxOvershoot = (CGRectGetWidth(self.centerContainerView.frame) - self.maximumLeftDrawerWidth) * DrawerOvershootPercentage;
+                let maxOvershoot = (self.centerContainerView.frame.width - self.maximumLeftDrawerWidth) * DrawerOvershootPercentage;
                 return self.originXForDrawerOriginAndTargetOriginOffset(originX, targetOffset: self.maximumLeftDrawerWidth, maxOvershoot: maxOvershoot)
             } else {
                 return self.maximumLeftDrawerWidth
@@ -624,7 +624,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
         return originX
     }
     
-    private func originXForDrawerOriginAndTargetOriginOffset(originX: CGFloat, targetOffset: CGFloat, maxOvershoot: CGFloat) -> CGFloat {
+    private func originXForDrawerOriginAndTargetOriginOffset(_ originX: CGFloat, targetOffset: CGFloat, maxOvershoot: CGFloat) -> CGFloat {
         let delta: CGFloat = abs(originX - targetOffset)
         let maxLinearPercentage = DrawerOvershootLinearRangePercentage
         let nonLinearRange = maxOvershoot * maxLinearPercentage
@@ -643,56 +643,56 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     // MARK: - Helpers
     
     private func setupGestureRecognizers() {
-        let pan = UIPanGestureRecognizer(target: self, action: "panGestureCallback:")
+        let pan = UIPanGestureRecognizer(target: self, action: #selector(DrawerController.panGestureCallback(_:)))
         pan.delegate = self
         self.view.addGestureRecognizer(pan)
         
-        let tap = UITapGestureRecognizer(target: self, action: "tapGestureCallback:")
+        let tap = UITapGestureRecognizer(target: self, action: #selector(DrawerController.tapGestureCallback(_:)))
         tap.delegate = self
         self.view.addGestureRecognizer(tap)
     }
     
-    private func childViewControllerForSide(drawerSide: DrawerSide) -> UIViewController? {
+    private func childViewControllerForSide(_ drawerSide: DrawerSide) -> UIViewController? {
         var childViewController: UIViewController?
         
         switch drawerSide {
-        case .Left:
+        case .left:
             childViewController = self.leftDrawerViewController
-        case .Right:
+        case .right:
             childViewController = self.rightDrawerViewController
-        case .None:
+        case .none:
             childViewController = self.centerViewController
         }
         
         return childViewController
     }
     
-    private func sideDrawerViewControllerForSide(drawerSide: DrawerSide) -> UIViewController? {
+    private func sideDrawerViewControllerForSide(_ drawerSide: DrawerSide) -> UIViewController? {
         var sideDrawerViewController: UIViewController?
         
-        if drawerSide != .None {
+        if drawerSide != .none {
             sideDrawerViewController = self.childViewControllerForSide(drawerSide)
         }
         
         return sideDrawerViewController
     }
     
-    private func prepareToPresentDrawer(drawer: DrawerSide, animated: Bool) {
-        var drawerToHide: DrawerSide = .None
+    private func prepareToPresentDrawer(_ drawer: DrawerSide, animated: Bool) {
+        var drawerToHide: DrawerSide = .none
         
-        if drawer == .Left {
-            drawerToHide = .Right
-        } else if drawer == .Right {
-            drawerToHide = .Left
+        if drawer == .left {
+            drawerToHide = .right
+        } else if drawer == .right {
+            drawerToHide = .left
         }
         
         if let sideDrawerViewControllerToHide = self.sideDrawerViewControllerForSide(drawerToHide) {
-            self.childControllerContainerView.sendSubviewToBack(sideDrawerViewControllerToHide.view)
-            sideDrawerViewControllerToHide.view.hidden = true
+            self.childControllerContainerView.sendSubview(toBack: sideDrawerViewControllerToHide.view)
+            sideDrawerViewControllerToHide.view.isHidden = true
         }
         
         if let sideDrawerViewControllerToPresent = self.sideDrawerViewControllerForSide(drawer) {
-            sideDrawerViewControllerToPresent.view.hidden = false
+            sideDrawerViewControllerToPresent.view.isHidden = false
             self.resetDrawerVisualStateForDrawerSide(drawer)
             sideDrawerViewControllerToPresent.view.frame = sideDrawerViewControllerToPresent.evo_visibleDrawerFrame
             self.updateDrawerVisualStateForDrawerSide(drawer, percentVisible: 0.0)
@@ -709,12 +709,12 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
             /** In the event this gets called a lot, we won't update the shadowPath
             unless it needs to be updated (like during rotation) */
             if self.centerContainerView.layer.shadowPath == nil {
-                self.centerContainerView.layer.shadowPath = UIBezierPath(rect: self.centerContainerView.bounds).CGPath
+                self.centerContainerView.layer.shadowPath = UIBezierPath(rect: self.centerContainerView.bounds).cgPath
             } else {
-                let currentPath = CGPathGetPathBoundingBox(self.centerContainerView.layer.shadowPath)
+                let currentPath = self.centerContainerView.layer.shadowPath?.boundingBoxOfPath
                 
-                if CGRectEqualToRect(currentPath, self.centerContainerView.bounds) == false {
-                    self.centerContainerView.layer.shadowPath = UIBezierPath(rect: self.centerContainerView.bounds).CGPath
+                if currentPath?.equalTo(self.centerContainerView.bounds) == false {
+                    self.centerContainerView.layer.shadowPath = UIBezierPath(rect: self.centerContainerView.bounds).cgPath
                 }
             }
         } else if (self.centerContainerView.layer.shadowPath != nil) {
@@ -725,8 +725,8 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
         }
     }
     
-    private func animationDurationForAnimationDistance(distance: CGFloat) -> NSTimeInterval {
-        return NSTimeInterval(max(distance / self.animationVelocity, DrawerMinimumAnimationDuration))
+    private func animationDurationForAnimationDistance(_ distance: CGFloat) -> TimeInterval {
+        return TimeInterval(max(distance / self.animationVelocity, DrawerMinimumAnimationDuration))
     }
     
     // MARK: - Size Methods
@@ -741,8 +741,8 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     - parameter completion: The block called when the animation is finished.
     
     */
-    public func setMaximumLeftDrawerWidth(width: CGFloat, animated: Bool, completion: ((Bool) -> Void)?) {
-        self.setMaximumDrawerWidth(width, forSide: .Left, animated: animated, completion: completion)
+    public func setMaximumLeftDrawerWidth(_ width: CGFloat, animated: Bool, completion: ((Bool) -> Void)?) {
+        self.setMaximumDrawerWidth(width, forSide: .left, animated: animated, completion: completion)
     }
     
     /**
@@ -755,40 +755,40 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     - parameter completion: The block called when the animation is finished.
     
     */
-    public func setMaximumRightDrawerWidth(width: CGFloat, animated: Bool, completion: ((Bool) -> Void)?) {
-        self.setMaximumDrawerWidth(width, forSide: .Right, animated: animated, completion: completion)
+    public func setMaximumRightDrawerWidth(_ width: CGFloat, animated: Bool, completion: ((Bool) -> Void)?) {
+        self.setMaximumDrawerWidth(width, forSide: .right, animated: animated, completion: completion)
     }
     
-    private func setMaximumDrawerWidth(width: CGFloat, forSide drawerSide: DrawerSide, animated: Bool, completion: ((Bool) -> Void)?) {
+    private func setMaximumDrawerWidth(_ width: CGFloat, forSide drawerSide: DrawerSide, animated: Bool, completion: ((Bool) -> Void)?) {
         assert({ () -> Bool in
             return width > 0
             }(), "width must be greater than 0")
         
         assert({ () -> Bool in
-            return drawerSide != .None
+            return drawerSide != .none
             }(), "drawerSide cannot be .None")
         
         if let sideDrawerViewController = self.sideDrawerViewControllerForSide(drawerSide) {
             var oldWidth: CGFloat = 0.0
             var drawerSideOriginCorrection: NSInteger = 1
             
-            if drawerSide == .Left {
+            if drawerSide == .left {
                 oldWidth = self._maximumLeftDrawerWidth
                 self._maximumLeftDrawerWidth = width
-            } else if (drawerSide == .Right) {
+            } else if (drawerSide == .right) {
                 oldWidth = self._maximumRightDrawerWidth
                 self._maximumRightDrawerWidth = width
                 drawerSideOriginCorrection = -1
             }
             
             let distance: CGFloat = abs(width - oldWidth)
-            let duration: NSTimeInterval = animated ? self.animationDurationForAnimationDistance(distance) : 0.0
+            let duration: TimeInterval = animated ? self.animationDurationForAnimationDistance(distance) : 0.0
             
             if self.openSide == drawerSide {
                 var newCenterRect = self.centerContainerView.frame
                 newCenterRect.origin.x = CGFloat(drawerSideOriginCorrection) * width
                 
-                UIView.animateWithDuration(duration, delay: 0.0, usingSpringWithDamping: self.drawerDampingFactor, initialSpringVelocity: self.animationVelocity / distance, options: [], animations: { () -> Void in
+                UIView.animate(withDuration: duration, delay: 0.0, usingSpringWithDamping: self.drawerDampingFactor, initialSpringVelocity: self.animationVelocity / distance, options: [], animations: { () -> Void in
                     self.centerContainerView.frame = newCenterRect
                     sideDrawerViewController.view.frame = sideDrawerViewController.evo_visibleDrawerFrame
                     }, completion: { (finished) -> Void in
@@ -804,17 +804,17 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     
     // MARK: - Setters
     
-    private func setRightDrawerViewController(rightDrawerViewController: UIViewController?) {
-        self.setDrawerViewController(rightDrawerViewController, forSide: .Right)
+    private func setRightDrawerViewController(_ rightDrawerViewController: UIViewController?) {
+        self.setDrawerViewController(rightDrawerViewController, forSide: .right)
     }
     
-    private func setLeftDrawerViewController(leftDrawerViewController: UIViewController?) {
-        self.setDrawerViewController(leftDrawerViewController, forSide: .Left)
+    private func setLeftDrawerViewController(_ leftDrawerViewController: UIViewController?) {
+        self.setDrawerViewController(leftDrawerViewController, forSide: .left)
     }
     
-    private func setDrawerViewController(viewController: UIViewController?, forSide drawerSide: DrawerSide) {
+    private func setDrawerViewController(_ viewController: UIViewController?, forSide drawerSide: DrawerSide) {
         assert({ () -> Bool in
-            return drawerSide != .None
+            return drawerSide != .none
             }(), "drawerSide cannot be .None")
         
         let currentSideViewController = self.sideDrawerViewControllerForSide(drawerSide)
@@ -827,34 +827,34 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
             currentSideViewController!.beginAppearanceTransition(false, animated: false)
             currentSideViewController!.view.removeFromSuperview()
             currentSideViewController!.endAppearanceTransition()
-            currentSideViewController!.willMoveToParentViewController(nil)
+            currentSideViewController!.willMove(toParentViewController: nil)
             currentSideViewController!.removeFromParentViewController()
         }
         
         var autoResizingMask = UIViewAutoresizing()
         
-        if drawerSide == .Left {
+        if drawerSide == .left {
             self._leftDrawerViewController = viewController
-            autoResizingMask = [.FlexibleRightMargin, .FlexibleHeight]
-        } else if drawerSide == .Right {
+            autoResizingMask = [.flexibleRightMargin, .flexibleHeight]
+        } else if drawerSide == .right {
             self._rightDrawerViewController = viewController
-            autoResizingMask = [.FlexibleLeftMargin, .FlexibleHeight]
+            autoResizingMask = [.flexibleLeftMargin, .flexibleHeight]
         }
         
         if viewController != nil {
             self.addChildViewController(viewController!)
             
-            if (self.openSide == drawerSide) && (self.childControllerContainerView.subviews as NSArray).containsObject(self.centerContainerView) {
+            if (self.openSide == drawerSide) && (self.childControllerContainerView.subviews as NSArray).contains(self.centerContainerView) {
                 self.childControllerContainerView.insertSubview(viewController!.view, belowSubview: self.centerContainerView)
                 viewController!.beginAppearanceTransition(true, animated: false)
                 viewController!.endAppearanceTransition()
             } else {
                 self.childControllerContainerView.addSubview(viewController!.view)
-                self.childControllerContainerView.sendSubviewToBack(viewController!.view)
-                viewController!.view.hidden = true
+                self.childControllerContainerView.sendSubview(toBack: viewController!.view)
+                viewController!.view.isHidden = true
             }
             
-            viewController!.didMoveToParentViewController(self)
+            viewController!.didMove(toParentViewController: self)
             viewController!.view.autoresizingMask = autoResizingMask
             viewController!.view.frame = viewController!.evo_visibleDrawerFrame
         }
@@ -862,13 +862,13 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     
     // MARK: - Updating the Center View Controller
     
-    private func setCenterViewController(centerViewController: UIViewController?, animated: Bool) {
+    private func setCenterViewController(_ centerViewController: UIViewController?, animated: Bool) {
         if self._centerViewController == centerViewController {
             return
         }
         
         if let oldCenterViewController = self._centerViewController {
-            oldCenterViewController.willMoveToParentViewController(nil)
+            oldCenterViewController.willMove(toParentViewController: nil)
             
             if animated == false {
                 oldCenterViewController.beginAppearanceTransition(false, animated: false)
@@ -888,8 +888,8 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
             self.addChildViewController(self._centerViewController!)
             self._centerViewController!.view.frame = self.childControllerContainerView.bounds
             self.centerContainerView.addSubview(self._centerViewController!.view)
-            self.childControllerContainerView.bringSubviewToFront(self.centerContainerView)
-            self._centerViewController!.view.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+            self.childControllerContainerView.bringSubview(toFront: self.centerContainerView)
+            self._centerViewController!.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             self.updateShadowForCenterView()
             
             if animated == false {
@@ -899,7 +899,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
                     self._centerViewController!.endAppearanceTransition()
                 }
                 
-                self._centerViewController!.didMoveToParentViewController(self)
+                self._centerViewController!.didMove(toParentViewController: self)
             }
         }
     }
@@ -914,8 +914,9 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     - parameter completion: The block called when the animation is finsihed.
     
     */
-    public func setCenterViewController(newCenterViewController: UIViewController, var withCloseAnimation animated: Bool, completion: ((Bool) -> Void)?) {
-        if self.openSide == .None {
+    public func setCenterViewController(_ newCenterViewController: UIViewController, withCloseAnimation animated: Bool, completion: ((Bool) -> Void)?) {
+        var animated = animated
+        if self.openSide == .none {
             // If a side drawer isn't open, there is nothing to animate
             animated = false
         }
@@ -933,7 +934,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
             self.closeDrawerAnimated(animated, completion: { (finished) in
                 if forwardAppearanceMethodsToCenterViewController {
                     self.centerViewController!.endAppearanceTransition()
-                    self.centerViewController!.didMoveToParentViewController(self)
+                    self.centerViewController!.didMove(toParentViewController: self)
                 }
                 
                 completion?(finished)
@@ -953,17 +954,17 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     - parameter completion: The block called when the animation is finsihed.
     
     */
-    public func setCenterViewController(newCenterViewController: UIViewController, withFullCloseAnimation animated: Bool, completion: ((Bool) -> Void)?) {
-        if self.openSide != .None && animated {
+    public func setCenterViewController(_ newCenterViewController: UIViewController, withFullCloseAnimation animated: Bool, completion: ((Bool) -> Void)?) {
+        if self.openSide != .none && animated {
             let forwardAppearanceMethodsToCenterViewController = (self.centerViewController! == newCenterViewController) == false
             let sideDrawerViewController = self.sideDrawerViewControllerForSide(self.openSide)
             
             var targetClosePoint: CGFloat = 0.0
             
-            if self.openSide == .Right {
-                targetClosePoint = -CGRectGetWidth(self.childControllerContainerView.bounds)
-            } else if self.openSide == .Left {
-                targetClosePoint = CGRectGetWidth(self.childControllerContainerView.bounds)
+            if self.openSide == .right {
+                targetClosePoint = -self.childControllerContainerView.bounds.width
+            } else if self.openSide == .left {
+                targetClosePoint = self.childControllerContainerView.bounds.width
             }
             
             let distance: CGFloat = abs(self.centerContainerView.frame.origin.x - targetClosePoint)
@@ -981,7 +982,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
             
             newCenterRect.origin.x = targetClosePoint
             
-            UIView.animateWithDuration(firstDuration, delay: 0.0, usingSpringWithDamping: self.drawerDampingFactor, initialSpringVelocity: distance / self.animationVelocity, options: [], animations: { () -> Void in
+            UIView.animate(withDuration: firstDuration, delay: 0.0, usingSpringWithDamping: self.drawerDampingFactor, initialSpringVelocity: distance / self.animationVelocity, options: [], animations: { () -> Void in
                 self.centerContainerView.frame = newCenterRect
                 sideDrawerViewController?.view.frame = self.childControllerContainerView.bounds
                 }, completion: { (finished) -> Void in
@@ -997,13 +998,13 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
                     
                     sideDrawerViewController?.beginAppearanceTransition(false, animated: animated)
                     
-                    UIView.animateWithDuration(self.animationDurationForAnimationDistance(CGRectGetWidth(self.childControllerContainerView.bounds)), delay: DrawerDefaultFullAnimationDelay, usingSpringWithDamping: self.drawerDampingFactor, initialSpringVelocity: CGRectGetWidth(self.childControllerContainerView.bounds) / self.animationVelocity, options: [], animations: { () -> Void in
+                    UIView.animate(withDuration: self.animationDurationForAnimationDistance(self.childControllerContainerView.bounds.width), delay: DrawerDefaultFullAnimationDelay, usingSpringWithDamping: self.drawerDampingFactor, initialSpringVelocity: self.childControllerContainerView.bounds.width / self.animationVelocity, options: [], animations: { () -> Void in
                         self.centerContainerView.frame = self.childControllerContainerView.bounds
                         self.updateDrawerVisualStateForDrawerSide(self.openSide, percentVisible: 0.0)
                         }, completion: { (finished) -> Void in
                             if forwardAppearanceMethodsToCenterViewController {
                                 self.centerViewController?.endAppearanceTransition()
-                                self.centerViewController?.didMoveToParentViewController(self)
+                                self.centerViewController?.didMove(toParentViewController: self)
                             }
                             
                             sideDrawerViewController?.endAppearanceTransition()
@@ -1013,7 +1014,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
                                 sideDrawerViewController!.view.frame = sideDrawerViewController!.evo_visibleDrawerFrame
                             }
                             
-                            self.openSide = .None
+                            self.openSide = .none
                             self.animatingDrawer = false
                             
                             completion?(finished)
@@ -1022,7 +1023,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
         } else {
             self.setCenterViewController(newCenterViewController, animated: animated)
             
-            if self.openSide != .None {
+            if self.openSide != .none {
                 self.closeDrawerAnimated(animated, completion: completion)
             } else if completion != nil {
                 completion!(true)
@@ -1039,9 +1040,9 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     - parameter completion: The block called when the animation is finsihed.
     
     */
-    public func bouncePreviewForDrawerSide(drawerSide: DrawerSide, completion: ((Bool) -> Void)?) {
+    public func bouncePreviewForDrawerSide(_ drawerSide: DrawerSide, completion: ((Bool) -> Void)?) {
         assert({ () -> Bool in
-            return drawerSide != .None
+            return drawerSide != .none
             }(), "drawerSide cannot be .None")
         
         self.bouncePreviewForDrawerSide(drawerSide, distance: DrawerDefaultBounceDistance, completion: nil)
@@ -1055,14 +1056,14 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     - parameter completion: The block called when the animation is finsihed.
     
     */
-    public func bouncePreviewForDrawerSide(drawerSide: DrawerSide, distance: CGFloat, completion: ((Bool) -> Void)?) {
+    public func bouncePreviewForDrawerSide(_ drawerSide: DrawerSide, distance: CGFloat, completion: ((Bool) -> Void)?) {
         assert({ () -> Bool in
-            return drawerSide != .None
+            return drawerSide != .none
             }(), "drawerSide cannot be .None")
         
         let sideDrawerViewController = self.sideDrawerViewControllerForSide(drawerSide)
         
-        if sideDrawerViewController == nil || self.openSide != .None {
+        if sideDrawerViewController == nil || self.openSide != .none {
             completion?(false)
             return
         } else {
@@ -1079,9 +1080,9 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
                 completion?(true)
             }
             
-            let modifier: CGFloat = (drawerSide == .Left) ? 1.0 : -1.0
+            let modifier: CGFloat = (drawerSide == .left) ? 1.0 : -1.0
             let animation = bounceKeyFrameAnimationForDistanceOnView(distance * modifier, view: self.centerContainerView)
-            self.centerContainerView.layer.addAnimation(animation, forKey: "bouncing")
+            self.centerContainerView.layer.add(animation, forKey: "bouncing")
             
             CATransaction.commit()
         }
@@ -1089,8 +1090,8 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     
     // MARK: - Gesture Handlers
     
-    func tapGestureCallback(tapGesture: UITapGestureRecognizer) {
-        if self.openSide != .None && self.animatingDrawer == false {
+    func tapGestureCallback(_ tapGesture: UITapGestureRecognizer) {
+        if self.openSide != .none && self.animatingDrawer == false {
             self.closeDrawerAnimated(true, completion: { (finished) in
                 if self.gestureCompletionBlock != nil {
                     self.gestureCompletionBlock!(self, tapGesture)
@@ -1099,30 +1100,30 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
         }
     }
     
-    func panGestureCallback(panGesture: UIPanGestureRecognizer) {
+    func panGestureCallback(_ panGesture: UIPanGestureRecognizer) {
         switch panGesture.state {
-        case .Began:
+        case .began:
             if self.animatingDrawer {
-                panGesture.enabled = false
+                panGesture.isEnabled = false
             } else {
                 self.startingPanRect = self.centerContainerView.frame
             }
-        case .Changed:
-            self.view.userInteractionEnabled = false
+        case .changed:
+            self.view.isUserInteractionEnabled = false
             var newFrame = self.startingPanRect
-            let translatedPoint = panGesture.translationInView(self.centerContainerView)
-            newFrame.origin.x = self.roundedOriginXForDrawerConstraints(CGRectGetMinX(self.startingPanRect) + translatedPoint.x)
-            newFrame = CGRectIntegral(newFrame)
+            let translatedPoint = panGesture.translation(in: self.centerContainerView)
+            newFrame.origin.x = self.roundedOriginXForDrawerConstraints(self.startingPanRect.minX + translatedPoint.x)
+            newFrame = newFrame.integral
             let xOffset = newFrame.origin.x
             
-            var visibleSide: DrawerSide = .None
+            var visibleSide: DrawerSide = .none
             var percentVisible: CGFloat = 0.0
             
             if xOffset > 0 {
-                visibleSide = .Left
+                visibleSide = .left
                 percentVisible = xOffset / self.maximumLeftDrawerWidth
             } else if xOffset < 0 {
-                visibleSide = .Right
+                visibleSide = .right
                 percentVisible = abs(xOffset) / self.maximumRightDrawerWidth
             }
             
@@ -1138,23 +1139,23 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
                     self.prepareToPresentDrawer(visibleSide, animated: false)
                     visibleSideDrawerViewController.endAppearanceTransition()
                     self.openSide = visibleSide
-                } else if visibleSide == .None {
-                    self.openSide = .None
+                } else if visibleSide == .none {
+                    self.openSide = .none
                 }
                 
                 self.updateDrawerVisualStateForDrawerSide(visibleSide, percentVisible: percentVisible)
-                self.centerContainerView.center = CGPoint(x: CGRectGetMidX(newFrame), y: CGRectGetMidY(newFrame))
+                self.centerContainerView.center = CGPoint(x: newFrame.midX, y: newFrame.midY)
             }
-        case .Ended, .Cancelled:
-            self.startingPanRect = CGRectNull
-            let velocity = panGesture.velocityInView(self.childControllerContainerView)
+        case .ended, .cancelled:
+            self.startingPanRect = CGRect.null
+            let velocity = panGesture.velocity(in: self.childControllerContainerView)
             self.finishAnimationForPanGestureWithXVelocity(velocity.x, completion:{ (finished) in
                 if self.gestureCompletionBlock != nil {
                     self.gestureCompletionBlock!(self, panGesture)
                 }
             })
             
-            self.view.userInteractionEnabled = true
+            self.view.isUserInteractionEnabled = true
         default:
             break
         }
@@ -1163,12 +1164,12 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     // MARK: - Open / Close Methods
     
     // DrawerSide enum is not exported to Objective-C, so use these two methods instead
-    public func toggleLeftDrawerSideAnimated(animated: Bool, completion: ((Bool) -> Void)?) {
-        self.toggleDrawerSide(.Left, animated: animated, completion: completion)
+    public func toggleLeftDrawerSideAnimated(_ animated: Bool, completion: ((Bool) -> Void)?) {
+        self.toggleDrawerSide(.left, animated: animated, completion: completion)
     }
     
-    public func toggleRightDrawerSideAnimated(animated: Bool, completion: ((Bool) -> Void)?) {
-        self.toggleDrawerSide(.Right, animated: animated, completion: completion)
+    public func toggleRightDrawerSideAnimated(_ animated: Bool, completion: ((Bool) -> Void)?) {
+        self.toggleDrawerSide(.right, animated: animated, completion: completion)
     }
     
     /**
@@ -1181,15 +1182,15 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     - parameter completion: The block that is called when the toggle is complete, or if no toggle took place at all.
     
     */
-    public func toggleDrawerSide(drawerSide: DrawerSide, animated: Bool, completion: ((Bool) -> Void)?) {
+    public func toggleDrawerSide(_ drawerSide: DrawerSide, animated: Bool, completion: ((Bool) -> Void)?) {
         assert({ () -> Bool in
-            return drawerSide != .None
+            return drawerSide != .none
             }(), "drawerSide cannot be .None")
         
-        if self.openSide == DrawerSide.None {
+        if self.openSide == DrawerSide.none {
             self.openDrawerSide(drawerSide, animated: animated, completion: completion)
         } else {
-            if (drawerSide == DrawerSide.Left && self.openSide == DrawerSide.Left) || (drawerSide == DrawerSide.Right && self.openSide == DrawerSide.Right) {
+            if (drawerSide == DrawerSide.left && self.openSide == DrawerSide.left) || (drawerSide == DrawerSide.right && self.openSide == DrawerSide.right) {
                 self.closeDrawerAnimated(animated, completion: completion)
             } else if completion != nil {
                 completion!(false)
@@ -1205,17 +1206,17 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     - parameter completion: The block that is called when the toggle is open.
     
     */
-    public func openDrawerSide(drawerSide: DrawerSide, animated: Bool, completion: ((Bool) -> Void)?) {
+    public func openDrawerSide(_ drawerSide: DrawerSide, animated: Bool, completion: ((Bool) -> Void)?) {
         assert({ () -> Bool in
-            return drawerSide != .None
+            return drawerSide != .none
             }(), "drawerSide cannot be .None")
         
         self.openDrawerSide(drawerSide, animated: animated, velocity: self.animationVelocity, animationOptions: [], completion: completion)
     }
     
-    private func openDrawerSide(drawerSide: DrawerSide, animated: Bool, velocity: CGFloat, animationOptions options: UIViewAnimationOptions, completion: ((Bool) -> Void)?) {
+    private func openDrawerSide(_ drawerSide: DrawerSide, animated: Bool, velocity: CGFloat, animationOptions options: UIViewAnimationOptions, completion: ((Bool) -> Void)?) {
         assert({ () -> Bool in
-            return drawerSide != .None
+            return drawerSide != .none
             }(), "drawerSide cannot be .None")
         
         if self.animatingDrawer {
@@ -1232,7 +1233,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
                 var newFrame: CGRect
                 let oldFrame = self.centerContainerView.frame
                 
-                if drawerSide == .Left {
+                if drawerSide == .left {
                     newFrame = self.centerContainerView.frame
                     newFrame.origin.x = self._maximumLeftDrawerWidth
                 } else {
@@ -1240,10 +1241,10 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
                     newFrame.origin.x = 0 - self._maximumRightDrawerWidth
                 }
                 
-                let distance = abs(CGRectGetMinX(oldFrame) - newFrame.origin.x)
-                let duration: NSTimeInterval = animated ? NSTimeInterval(max(distance / abs(velocity), DrawerMinimumAnimationDuration)) : 0.0
+                let distance = abs(oldFrame.minX - newFrame.origin.x)
+                let duration: TimeInterval = animated ? TimeInterval(max(distance / abs(velocity), DrawerMinimumAnimationDuration)) : 0.0
                 
-                UIView.animateWithDuration(duration, delay: 0.0, usingSpringWithDamping: self.drawerDampingFactor, initialSpringVelocity: velocity / distance, options: options, animations: { () -> Void in
+                UIView.animate(withDuration: duration, delay: 0.0, usingSpringWithDamping: self.drawerDampingFactor, initialSpringVelocity: velocity / distance, options: options, animations: { () -> Void in
                     self.setNeedsStatusBarAppearanceUpdate()
                     self.centerContainerView.frame = newFrame
                     self.updateDrawerVisualStateForDrawerSide(drawerSide, percentVisible: 1.0)
@@ -1270,34 +1271,34 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     - parameter completion: The block that is called when the close is complete
     
     */
-    public func closeDrawerAnimated(animated: Bool, completion: ((Bool) -> Void)?) {
+    public func closeDrawerAnimated(_ animated: Bool, completion: ((Bool) -> Void)?) {
         self.closeDrawerAnimated(animated, velocity: self.animationVelocity, animationOptions: [], completion: completion)
     }
     
-    private func closeDrawerAnimated(animated: Bool, velocity: CGFloat, animationOptions options: UIViewAnimationOptions, completion: ((Bool) -> Void)?) {
+    private func closeDrawerAnimated(_ animated: Bool, velocity: CGFloat, animationOptions options: UIViewAnimationOptions, completion: ((Bool) -> Void)?) {
         if self.animatingDrawer {
             completion?(false)
         } else {
             self.animatingDrawer = animated
             let newFrame = self.childControllerContainerView.bounds
             
-            let distance = abs(CGRectGetMinX(self.centerContainerView.frame))
-            let duration: NSTimeInterval = animated ? NSTimeInterval(max(distance / abs(velocity), DrawerMinimumAnimationDuration)) : 0.0
+            let distance = abs(self.centerContainerView.frame.minX)
+            let duration: TimeInterval = animated ? TimeInterval(max(distance / abs(velocity), DrawerMinimumAnimationDuration)) : 0.0
             
-            let leftDrawerVisible = CGRectGetMinX(self.centerContainerView.frame) > 0
-            let rightDrawerVisible = CGRectGetMinX(self.centerContainerView.frame) < 0
+            let leftDrawerVisible = self.centerContainerView.frame.minX > 0
+            let rightDrawerVisible = self.centerContainerView.frame.minX < 0
             
-            var visibleSide: DrawerSide = .None
+            var visibleSide: DrawerSide = .none
             var percentVisible: CGFloat = 0.0
             
             if leftDrawerVisible {
-                let visibleDrawerPoint = CGRectGetMinX(self.centerContainerView.frame)
+                let visibleDrawerPoint = self.centerContainerView.frame.minX
                 percentVisible = max(0.0, visibleDrawerPoint / self._maximumLeftDrawerWidth)
-                visibleSide = .Left
+                visibleSide = .left
             } else if rightDrawerVisible {
-                let visibleDrawerPoints = CGRectGetWidth(self.centerContainerView.frame) - CGRectGetMaxX(self.centerContainerView.frame)
+                let visibleDrawerPoints = self.centerContainerView.frame.width - self.centerContainerView.frame.maxX
                 percentVisible = max(0.0, visibleDrawerPoints / self._maximumRightDrawerWidth)
-                visibleSide = .Right
+                visibleSide = .right
             }
             
             let sideDrawerViewController = self.sideDrawerViewControllerForSide(visibleSide)
@@ -1305,13 +1306,13 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
             self.updateDrawerVisualStateForDrawerSide(visibleSide, percentVisible: percentVisible)
             sideDrawerViewController?.beginAppearanceTransition(false, animated: animated)
             
-            UIView.animateWithDuration(duration, delay: 0.0, usingSpringWithDamping: self.drawerDampingFactor, initialSpringVelocity: velocity / distance, options: options, animations: { () -> Void in
+            UIView.animate(withDuration: duration, delay: 0.0, usingSpringWithDamping: self.drawerDampingFactor, initialSpringVelocity: velocity / distance, options: options, animations: { () -> Void in
                 self.setNeedsStatusBarAppearanceUpdate()
                 self.centerContainerView.frame = newFrame
                 self.updateDrawerVisualStateForDrawerSide(visibleSide, percentVisible: 0.0)
                 }, completion: { (finished) -> Void in
                     sideDrawerViewController?.endAppearanceTransition()
-                    self.openSide = .None
+                    self.openSide = .none
                     self.resetDrawerVisualStateForDrawerSide(visibleSide)
                     self.animatingDrawer = false
                     completion?(finished)
@@ -1324,53 +1325,53 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     public override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.view.backgroundColor = UIColor.blackColor()
+        self.view.backgroundColor = UIColor.black()
         
         self.setupGestureRecognizers()
     }
     
-    public override func viewWillAppear(animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.centerViewController?.beginAppearanceTransition(true, animated: animated)
         
-        if self.openSide == .Left {
+        if self.openSide == .left {
             self.leftDrawerViewController?.beginAppearanceTransition(true, animated: animated)
-        } else if self.openSide == .Right {
+        } else if self.openSide == .right {
             self.rightDrawerViewController?.beginAppearanceTransition(true, animated: animated)
         }
     }
     
-    public override func viewDidAppear(animated: Bool) {
+    public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         self.updateShadowForCenterView()
         self.centerViewController?.endAppearanceTransition()
         
-        if self.openSide == .Left {
+        if self.openSide == .left {
             self.leftDrawerViewController?.endAppearanceTransition()
-        } else if self.openSide == .Right {
+        } else if self.openSide == .right {
             self.rightDrawerViewController?.endAppearanceTransition()
         }
     }
     
-    public override func viewWillDisappear(animated: Bool) {
+    public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.centerViewController?.beginAppearanceTransition(false, animated: animated)
         
-        if self.openSide == .Left {
+        if self.openSide == .left {
             self.leftDrawerViewController?.beginAppearanceTransition(false, animated: animated)
-        } else if self.openSide == .Right {
+        } else if self.openSide == .right {
             self.rightDrawerViewController?.beginAppearanceTransition(false, animated: animated)
         }
     }
     
-    public override func viewDidDisappear(animated: Bool) {
+    public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         self.centerViewController?.endAppearanceTransition()
         
-        if self.openSide == .Left {
+        if self.openSide == .left {
             self.leftDrawerViewController?.endAppearanceTransition()
-        } else if self.openSide == .Right {
+        } else if self.openSide == .right {
             self.rightDrawerViewController?.endAppearanceTransition()
         }
     }
@@ -1381,16 +1382,16 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     
     // MARK: - Rotation
     
-    public override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
+    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
         
         //If a rotation begins, we are going to cancel the current gesture and reset transform and anchor points so everything works correctly
         var gestureInProgress = false
         
         for gesture in self.view.gestureRecognizers! as [UIGestureRecognizer] {
-            if gesture.state == .Changed {
-                gesture.enabled = false
-                gesture.enabled = true
+            if gesture.state == .changed {
+                gesture.isEnabled = false
+                gesture.isEnabled = true
                 gestureInProgress = true
             }
             
@@ -1399,7 +1400,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
             }
         }
         
-        coordinator.animateAlongsideTransition({ (context) -> Void in
+        coordinator.animate(alongsideTransition: { (context) -> Void in
             //We need to support the shadow path rotation animation
             //Inspired from here: http://blog.radi.ws/post/8348898129/calayers-shadowpath-and-uiview-autoresizing
             if self.showsShadows {
@@ -1412,7 +1413,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
                     transition.fromValue = oldShadowPath
                     transition.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
                     transition.duration = context.transitionDuration()
-                    self.centerContainerView.layer.addAnimation(transition, forKey: "transition")
+                    self.centerContainerView.layer.add(transition, forKey: "transition")
                 }
             }
         }, completion:nil)
@@ -1420,25 +1421,25 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     
     // MARK: - UIGestureRecognizerDelegate
     
-    public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldReceiveTouch touch: UITouch) -> Bool {
-        if self.openSide == .None {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        if self.openSide == .none {
             let possibleOpenGestureModes = self.possibleOpenGestureModesForGestureRecognizer(gestureRecognizer, withTouch: touch)
             
-            return !self.openDrawerGestureModeMask.intersect(possibleOpenGestureModes).isEmpty
+            return !self.openDrawerGestureModeMask.intersection(possibleOpenGestureModes).isEmpty
         } else {
             let possibleCloseGestureModes = self.possibleCloseGestureModesForGestureRecognizer(gestureRecognizer, withTouch: touch)
             
-            return !self.closeDrawerGestureModeMask.intersect(possibleCloseGestureModes).isEmpty
+            return !self.closeDrawerGestureModeMask.intersection(possibleCloseGestureModes).isEmpty
         }
     }
     
     // MARK: - Gesture Recognizer Delegate Helpers
     
-    func possibleCloseGestureModesForGestureRecognizer(gestureRecognizer: UIGestureRecognizer, withTouch touch: UITouch) -> CloseDrawerGestureMode {
-        let point = touch.locationInView(self.childControllerContainerView)
+    func possibleCloseGestureModesForGestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, withTouch touch: UITouch) -> CloseDrawerGestureMode {
+        let point = touch.location(in: self.childControllerContainerView)
         var possibleCloseGestureModes: CloseDrawerGestureMode = []
         
-        if gestureRecognizer.isKindOfClass(UITapGestureRecognizer) {
+        if gestureRecognizer.isKind(of: UITapGestureRecognizer.self) {
             if self.isPointContainedWithinNavigationRect(point) {
                 possibleCloseGestureModes.insert(.TapNavigationBar)
             }
@@ -1446,7 +1447,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
             if self.isPointContainedWithinCenterViewContentRect(point) {
                 possibleCloseGestureModes.insert(.TapCenterView)
             }
-        } else if gestureRecognizer.isKindOfClass(UIPanGestureRecognizer) {
+        } else if gestureRecognizer.isKind(of: UIPanGestureRecognizer.self) {
             if self.isPointContainedWithinNavigationRect(point) {
                 possibleCloseGestureModes.insert(.PanningNavigationBar)
             }
@@ -1455,11 +1456,11 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
                 possibleCloseGestureModes.insert(.PanningCenterView)
             }
             
-            if self.isPointContainedWithinRightBezelRect(point) && self.openSide == .Left {
+            if self.isPointContainedWithinRightBezelRect(point) && self.openSide == .left {
                 possibleCloseGestureModes.insert(.BezelPanningCenterView)
             }
             
-            if self.isPointContainedWithinLeftBezelRect(point) && self.openSide == .Right {
+            if self.isPointContainedWithinLeftBezelRect(point) && self.openSide == .right {
                 possibleCloseGestureModes.insert(.BezelPanningCenterView)
             }
             
@@ -1477,11 +1478,11 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
         return possibleCloseGestureModes
     }
     
-    func possibleOpenGestureModesForGestureRecognizer(gestureRecognizer: UIGestureRecognizer, withTouch touch: UITouch) -> OpenDrawerGestureMode {
-        let point = touch.locationInView(self.childControllerContainerView)
+    func possibleOpenGestureModesForGestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, withTouch touch: UITouch) -> OpenDrawerGestureMode {
+        let point = touch.location(in: self.childControllerContainerView)
         var possibleOpenGestureModes: OpenDrawerGestureMode = []
         
-        if gestureRecognizer.isKindOfClass(UIPanGestureRecognizer) {
+        if gestureRecognizer.isKind(of: UIPanGestureRecognizer.self) {
             if self.isPointContainedWithinNavigationRect(point) {
                 possibleOpenGestureModes.insert(.PanningNavigationBar)
             }
@@ -1508,42 +1509,42 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
         return possibleOpenGestureModes
     }
     
-    func isPointContainedWithinNavigationRect(point: CGPoint) -> Bool {
-        var navigationBarRect = CGRectNull
+    func isPointContainedWithinNavigationRect(_ point: CGPoint) -> Bool {
+        var navigationBarRect = CGRect.null
         
         if let centerViewController = self.centerViewController {
-            if centerViewController.isKindOfClass(UINavigationController) {
+            if centerViewController.isKind(of: UINavigationController.self) {
                 let navBar = (self.centerViewController as! UINavigationController).navigationBar
-                navigationBarRect = navBar.convertRect(navBar.bounds, toView: self.childControllerContainerView)
-                navigationBarRect = CGRectIntersection(navigationBarRect, self.childControllerContainerView.bounds)
+                navigationBarRect = navBar.convert(navBar.bounds, to: self.childControllerContainerView)
+                navigationBarRect = navigationBarRect.intersection(self.childControllerContainerView.bounds)
             }
         }
         
-        return CGRectContainsPoint(navigationBarRect, point)
+        return navigationBarRect.contains(point)
     }
     
-    func isPointContainedWithinCenterViewContentRect(point: CGPoint) -> Bool {
+    func isPointContainedWithinCenterViewContentRect(_ point: CGPoint) -> Bool {
         var centerViewContentRect = self.centerContainerView.frame
-        centerViewContentRect = CGRectIntersection(centerViewContentRect, self.childControllerContainerView.bounds)
+        centerViewContentRect = centerViewContentRect.intersection(self.childControllerContainerView.bounds)
         
-        return CGRectContainsPoint(centerViewContentRect, point) && self.isPointContainedWithinNavigationRect(point) == false
+        return centerViewContentRect.contains(point) && self.isPointContainedWithinNavigationRect(point) == false
     }
     
-    func isPointContainedWithinLeftBezelRect(point: CGPoint) -> Bool {
-        var leftBezelRect = CGRectNull
-        var tempRect = CGRectNull
+    func isPointContainedWithinLeftBezelRect(_ point: CGPoint) -> Bool {
+        var leftBezelRect = CGRect.null
+        var tempRect = CGRect.null
         
-        CGRectDivide(self.childControllerContainerView.bounds, &leftBezelRect, &tempRect, bezelRange, .MinXEdge)
+        self.childControllerContainerView.bounds.divide(slice: &leftBezelRect, remainder: &tempRect, amount: bezelRange, edge: .minXEdge)
         
-        return CGRectContainsPoint(leftBezelRect, point) && self.isPointContainedWithinCenterViewContentRect(point)
+        return leftBezelRect.contains(point) && self.isPointContainedWithinCenterViewContentRect(point)
     }
     
-    func isPointContainedWithinRightBezelRect(point: CGPoint) -> Bool {
-        var rightBezelRect = CGRectNull
-        var tempRect = CGRectNull
+    func isPointContainedWithinRightBezelRect(_ point: CGPoint) -> Bool {
+        var rightBezelRect = CGRect.null
+        var tempRect = CGRect.null
         
-        CGRectDivide(self.childControllerContainerView.bounds, &rightBezelRect, &tempRect, bezelRange, .MaxXEdge)
+        self.childControllerContainerView.bounds.divide(slice: &rightBezelRect, remainder: &tempRect, amount: bezelRange, edge: .maxXEdge)
         
-        return CGRectContainsPoint(rightBezelRect, point) && self.isPointContainedWithinCenterViewContentRect(point)
+        return rightBezelRect.contains(point) && self.isPointContainedWithinCenterViewContentRect(point)
     }
 }

--- a/DrawerController/DrawerVisualState.swift
+++ b/DrawerController/DrawerVisualState.swift
@@ -39,10 +39,10 @@ public struct DrawerVisualState {
             var translateTransform = CATransform3DIdentity
             var sideDrawerViewController: UIViewController?
             
-            if drawerSide == DrawerSide.Left {
+            if drawerSide == DrawerSide.left {
                 sideDrawerViewController = drawerController.leftDrawerViewController
                 translateTransform = CATransform3DMakeTranslation((maxDistance - distance), 0, 0)
-            } else if drawerSide == DrawerSide.Right {
+            } else if drawerSide == DrawerSide.right {
                 sideDrawerViewController = drawerController.rightDrawerViewController
                 translateTransform = CATransform3DMakeTranslation(-(maxDistance-distance), 0.0, 0.0)
             }
@@ -77,7 +77,7 @@ public struct DrawerVisualState {
             var xOffset: CGFloat
             var angle: CGFloat = 0.0
             
-            if drawerSide == .Left {
+            if drawerSide == .left {
                 sideDrawerViewController = drawerController.leftDrawerViewController
                 anchorPoint = CGPoint(x: 1.0, y: 0.5)
                 maxDrawerWidth = max(drawerController.maximumLeftDrawerWidth, drawerController.visibleLeftDrawerWidth)
@@ -93,7 +93,7 @@ public struct DrawerVisualState {
             
             sideDrawerViewController?.view.layer.anchorPoint = anchorPoint
             sideDrawerViewController?.view.layer.shouldRasterize = true
-            sideDrawerViewController?.view.layer.rasterizationScale = UIScreen.mainScreen().scale
+            sideDrawerViewController?.view.layer.rasterizationScale = UIScreen.main().scale
             
             var swingingDoorTransform: CATransform3D = CATransform3DIdentity
            
@@ -110,7 +110,7 @@ public struct DrawerVisualState {
                 var overshootTransform = CATransform3DMakeScale(percentVisible, 1.0, 1.0)
                 var scalingModifier: CGFloat = 1.0
                 
-                if (drawerSide == .Right) {
+                if (drawerSide == .right) {
                     scalingModifier = -1.0
                 }
                 
@@ -131,7 +131,7 @@ public struct DrawerVisualState {
     
     - returns: The visual state block.
     */
-    public static func parallaxVisualStateBlock(parallaxFactor: CGFloat) -> DrawerControllerDrawerVisualStateBlock {
+    public static func parallaxVisualStateBlock(_ parallaxFactor: CGFloat) -> DrawerControllerDrawerVisualStateBlock {
         let visualStateBlock: DrawerControllerDrawerVisualStateBlock = { (drawerController, drawerSide, percentVisible) -> Void in
             
             assert({ () -> Bool in
@@ -141,7 +141,7 @@ public struct DrawerVisualState {
             var transform: CATransform3D = CATransform3DIdentity
             var sideDrawerViewController: UIViewController?
             
-            if (drawerSide == .Left) {
+            if (drawerSide == .left) {
                 sideDrawerViewController = drawerController.leftDrawerViewController
                 let distance: CGFloat = max(drawerController.maximumLeftDrawerWidth, drawerController.visibleLeftDrawerWidth)
                 
@@ -151,7 +151,7 @@ public struct DrawerVisualState {
                     transform = CATransform3DMakeScale(percentVisible, 1.0, 1.0)
                     transform = CATransform3DTranslate(transform, drawerController.maximumLeftDrawerWidth * (percentVisible - 1.0) / 2, 0.0, 0.0)
                 }
-            } else if (drawerSide == .Right) {
+            } else if (drawerSide == .right) {
                 sideDrawerViewController = drawerController.rightDrawerViewController
                 let distance: CGFloat = max(drawerController.maximumRightDrawerWidth, drawerController.visibleRightDrawerWidth)
                 
@@ -174,11 +174,11 @@ public struct DrawerVisualState {
             
             var hamburgerItem: DrawerBarButtonItem?
             if let navController = drawerController.centerViewController as? UINavigationController {
-                if (drawerSide == .Left) {
+                if (drawerSide == .left) {
                     if let item = navController.topViewController!.navigationItem.leftBarButtonItem as? DrawerBarButtonItem {
                         hamburgerItem = item
                     }
-                } else if (drawerSide == .Right) {
+                } else if (drawerSide == .right) {
                     if let item = navController.topViewController!.navigationItem.rightBarButtonItem as? DrawerBarButtonItem {
                         hamburgerItem = item
                     }


### PR DESCRIPTION
I ran the Xcode 8 automatic migration from Swift 2 to Swift 3 and updated optimization level as recommended by Xcode. Should now work with Xcode 8.

Anybody interested in trying this out now (in case it doesn't get merged very soon) simply integrate [my fork](https://github.com/Dschee/DrawerController) e.g. via Carthage by using the following:

```
github "Dschee/DrawerController"
```