### PR TITLE
bugfix: re-enable panGesture

### DIFF
--- a/DrawerController.podspec
+++ b/DrawerController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'DrawerController'
-  s.version = '1.1.0'
+  s.version = '1.1.1'
   s.license = { :type => 'MIT', :file => 'LICENSE' }
   s.homepage = 'https://github.com/sascha/DrawerController'
   s.authors = { 'Sascha Schwabbauer' => 'sascha@evolved.io',

--- a/DrawerController/DrawerController.swift
+++ b/DrawerController/DrawerController.swift
@@ -1153,7 +1153,7 @@ public class DrawerController: UIViewController, UIGestureRecognizerDelegate {
                     self.gestureCompletionBlock!(self, panGesture)
                 }
             })
-            
+            panGesture.enabled = true
             self.view.userInteractionEnabled = true
         default:
             break


### PR DESCRIPTION
please add this line, because sometimes `panGesture` is disabled (see in line `1106`), but is never re-enabled again :)

```swift
func panGestureCallback(panGesture: UIPanGestureRecognizer) {
        switch panGesture.state {
        case .Began:
            if self.animatingDrawer {
                panGesture.enabled = false // <-------------------------------------
            } else {
                self.startingPanRect = self.centerContainerView.frame
            }
[...]
```