### PR TITLE
Orientation ignored centerViewController's orientation

### DIFF
--- a/DrawerController/DrawerController.swift
+++ b/DrawerController/DrawerController.swift
@@ -1543,4 +1543,18 @@ open class DrawerController: UIViewController, UIGestureRecognizerDelegate {
 
         return rightBezelRect.contains(point) && self.isPointContained(withinCenterViewContentRect: point)
     }
+    
+    override open var shouldAutorotate: Bool {
+        if let controller = centerViewController {
+            return controller.shouldAutorotate
+        }
+        return super.shouldAutorotate
+    }
+    
+    open override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        if let controller = centerViewController {
+            return controller.supportedInterfaceOrientations
+        }
+        return super.supportedInterfaceOrientations
+    }
 }


### PR DESCRIPTION
Even though centerViewController's orientation was changed, DrawerController ignored it and it was possible to rotate it. Now it considers it, I think it makes more sense.
