### PR TITLE
Update DrawerController.swift

### DIFF
--- a/DrawerController/DrawerController.swift
+++ b/DrawerController/DrawerController.swift
@@ -515,15 +515,15 @@ open class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     open override func decodeRestorableState(with coder: NSCoder) {
         super.decodeRestorableState(with: coder)
         
-        if let leftDrawerViewController: AnyObject = coder.decodeObject(forKey: DrawerLeftDrawerKey) as AnyObject? {
+        if (self.leftDrawerViewController == nil) && (let leftDrawerViewController: AnyObject = coder.decodeObject(forKey: DrawerLeftDrawerKey) as AnyObject?) {
             self.leftDrawerViewController = leftDrawerViewController as? UIViewController
         }
         
-        if let rightDrawerViewController: AnyObject = coder.decodeObject(forKey: DrawerRightDrawerKey) as AnyObject? {
+        if (self.rightDrawerViewController == nil) && (let rightDrawerViewController: AnyObject = coder.decodeObject(forKey: DrawerRightDrawerKey) as AnyObject?) {
             self.rightDrawerViewController = rightDrawerViewController as? UIViewController
         }
         
-        if let centerViewController: AnyObject = coder.decodeObject(forKey: DrawerCenterKey) as AnyObject? {
+        if (self.centerViewController == nil) && (let centerViewController: AnyObject = coder.decodeObject(forKey: DrawerCenterKey) as AnyObject?) {
             self.centerViewController = centerViewController as? UIViewController
         }
         


### PR DESCRIPTION
Left, tight and centre view controllers may be set by the user in the willFinishLaunchingWithOptions method. If this is the case, we do not need to reassign them in the decodeRestorableState method.

Double reassignment happens if:

1) User instantiates DrawerController with left and centre controller in the willFinishLaunchingWithOptions method
2) User returns all relevant view controllers in the viewControllerWithRestorationIdentifierPath method. Following this, decodeRestorableState is called on DrawerController and left and centre controllers are reassigned.

The proposed PR ensures that controllers are only assigned in the decodeRestorableState method if they are not already assigned by the user. Seems quite logical :)