### PR TITLE
3.2 release

### DIFF
--- a/DrawerController/DrawerBarButtonItem.swift
+++ b/DrawerController/DrawerBarButtonItem.swift
@@ -28,17 +28,22 @@ open class DrawerBarButtonItem: UIBarButtonItem {
     // MARK: - Initializers
     
     public override init() {
-        self.menuButton = AnimatedMenuButton(frame: CGRect(x: 0, y: 0, width: 30, height: 30))
+        self.menuButton = AnimatedMenuButton(frame: CGRect(x: 0, y: 0, width: 26, height: 26))
         super.init()
         self.customView = self.menuButton
     }
-
+    
     public convenience init(target: AnyObject?, action: Selector) {
         self.init(target: target, action: action, menuIconColor: UIColor.gray)
     }
-
+    
     public convenience init(target: AnyObject?, action: Selector, menuIconColor: UIColor) {
-        let menuButton = AnimatedMenuButton(frame: CGRect(x: 0, y: 0, width: 30, height: 30), strokeColor: menuIconColor)
+        self.init(target: target, action: action, menuIconColor: menuIconColor, animatable: true)
+    }
+    
+    public convenience init(target: AnyObject?, action: Selector, menuIconColor: UIColor, animatable:Bool) {
+        let menuButton = AnimatedMenuButton(frame: CGRect(x: 0, y: 0, width: 26, height: 26), strokeColor: menuIconColor)
+        menuButton.animatable = animatable
         menuButton.addTarget(target, action: action, for: UIControlEvents.touchUpInside)
         self.init(customView: menuButton)
         
@@ -46,7 +51,7 @@ open class DrawerBarButtonItem: UIBarButtonItem {
     }
     
     public required init?(coder aDecoder: NSCoder) {
-        self.menuButton = AnimatedMenuButton(frame: CGRect(x: 0, y: 0, width: 30, height: 30))
+        self.menuButton = AnimatedMenuButton(frame: CGRect(x: 0, y: 0, width: 26, height: 26))
         super.init(coder: aDecoder)
         self.customView = self.menuButton
     }

--- a/DrawerController/DrawerController.swift
+++ b/DrawerController/DrawerController.swift
@@ -333,6 +333,7 @@ open class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     }
     
     open var animationVelocity = DrawerDefaultAnimationVelocity
+    open var minimumAnimationDuration = DrawerMinimumAnimationDuration
     fileprivate var animatingDrawer: Bool = false {
         didSet {
             self.view.isUserInteractionEnabled = !self.animatingDrawer
@@ -740,7 +741,7 @@ open class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     }
     
     fileprivate func animationDuration(forAnimationDistance distance: CGFloat) -> TimeInterval {
-        return TimeInterval(max(distance / self.animationVelocity, DrawerMinimumAnimationDuration))
+        return TimeInterval(max(distance / self.animationVelocity, minimumAnimationDuration))
     }
     
     // MARK: - Size Methods
@@ -1257,7 +1258,7 @@ open class DrawerController: UIViewController, UIGestureRecognizerDelegate {
                 }
                 
                 let distance = abs(oldFrame.minX - newFrame.origin.x)
-                let duration: TimeInterval = animated ? TimeInterval(max(distance / abs(velocity), DrawerMinimumAnimationDuration)) : 0.0
+                let duration: TimeInterval = animated ? TimeInterval(max(distance / abs(velocity), minimumAnimationDuration)) : 0.0
                 
                 UIView.animate(withDuration: duration, delay: 0.0, usingSpringWithDamping: self.drawerDampingFactor, initialSpringVelocity: velocity / distance, options: options, animations: { () -> Void in
                     self.setNeedsStatusBarAppearanceUpdate()
@@ -1298,7 +1299,7 @@ open class DrawerController: UIViewController, UIGestureRecognizerDelegate {
             let newFrame = self.childControllerContainerView.bounds
             
             let distance = abs(self.centerContainerView.frame.minX)
-            let duration: TimeInterval = animated ? TimeInterval(max(distance / abs(velocity), DrawerMinimumAnimationDuration)) : 0.0
+            let duration: TimeInterval = animated ? TimeInterval(max(distance / abs(velocity), minimumAnimationDuration)) : 0.0
             
             let leftDrawerVisible = self.centerContainerView.frame.minX > 0
             let rightDrawerVisible = self.centerContainerView.frame.minX < 0

--- a/DrawerController/DrawerController.swift
+++ b/DrawerController/DrawerController.swift
@@ -515,16 +515,22 @@ open class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     open override func decodeRestorableState(with coder: NSCoder) {
         super.decodeRestorableState(with: coder)
         
-        if let leftDrawerViewController: AnyObject = coder.decodeObject(forKey: DrawerLeftDrawerKey) as AnyObject? {
-            self.leftDrawerViewController = leftDrawerViewController as? UIViewController
+        if self.leftDrawerViewController == nil {
+            if let leftDrawerViewController = coder.decodeObject(forKey: DrawerLeftDrawerKey) as? UIViewController {
+                self.leftDrawerViewController = leftDrawerViewController
+            }
         }
         
-        if let rightDrawerViewController: AnyObject = coder.decodeObject(forKey: DrawerRightDrawerKey) as AnyObject? {
-            self.rightDrawerViewController = rightDrawerViewController as? UIViewController
+        if self.rightDrawerViewController == nil {
+            if let rightDrawerViewController = coder.decodeObject(forKey: DrawerRightDrawerKey) as? UIViewController {
+                self.rightDrawerViewController = rightDrawerViewController
+            }
         }
         
-        if let centerViewController: AnyObject = coder.decodeObject(forKey: DrawerCenterKey) as AnyObject? {
-            self.centerViewController = centerViewController as? UIViewController
+        if self.centerViewController == nil {
+            if let centerViewController = coder.decodeObject(forKey: DrawerCenterKey) as? UIViewController {
+                self.centerViewController = centerViewController
+            }
         }
         
         if let openSide = DrawerSide(rawValue: coder.decodeInteger(forKey: DrawerOpenSideKey)) {


### PR DESCRIPTION
### Style update ###

Default implementation of DrawerBarButtonItem was of iOS 6 style. It is way outdated!

Current commit changes the design to be of iOS 7+ style. The size is reduced from 30 to 26 pixels (within the recommended boundary). The lines are drawn without rounded caps.

### Support for disabling animations ###

By default, AnimatedMenuButton supports animations and uses CAShapeLayer to draw lines.

The problem is that in the majority of cases animations are not needed + CAShapeLayer has weird antialiasing. I tried to turn it off and didn't manage to do so.

This commit therefore introduces the possibility to instantiate AnimatedMenuButton without animations. In this case, CAShapeLayers are not used and instead all lines are drawn within the drawRect method.

In order to support this behaviour DrawerBarButtonItem exposes a new convenience initialiser: init(target: AnyObject?, action: Selector, menuIconColor: UIColor, animatable:Bool). By default, old behaviour is preserved (i.e. button is animatable).

However, users can now choose to opt out from this behaviour. Another benefit is that straight lines on iPhone 7+ are drawn with anti aliasing if CAShapeLayers are used. If, however, they are not used, the lines are solid color 3px.

### Prevents double reassignment of view controller ###

Assigning view controllers in the decodeRestorableState method is only needed if the user did not set them already.

### Exposure of minimumAnimationDuration property ###

By default, minimum animation duration is set to 0.15. This is too low for many applications. Current commit lets users control the minimumAnimationDuration. By default, it is set to 0.15 which means that without extra changes original behaviour will be preserved.