### PR TITLE
Fix top layout guide calculation for side controllers.

### DIFF
--- a/DrawerController/DrawerController.swift
+++ b/DrawerController/DrawerController.swift
@@ -711,7 +711,10 @@ open class DrawerController: UIViewController, UIGestureRecognizerDelegate {
     if let sideDrawerViewControllerToPresent = self.sideDrawerViewController(for: drawer) {
       sideDrawerViewControllerToPresent.view.isHidden = false
       self.resetDrawerVisualState(for: drawer)
+        
+      sideDrawerViewControllerToPresent.view.setNeedsUpdateConstraints()
       sideDrawerViewControllerToPresent.view.frame = sideDrawerViewControllerToPresent.evo_visibleDrawerFrame
+        
       self.updateDrawerVisualState(for: drawer, fractionVisible: 0.0)
       sideDrawerViewControllerToPresent.beginAppearanceTransition(true, animated: animated)
     }
@@ -871,9 +874,9 @@ open class DrawerController: UIViewController, UIGestureRecognizerDelegate {
         viewController!.view.isHidden = true
       }
 
-      viewController!.didMove(toParentViewController: self)
-      viewController!.view.autoresizingMask = autoResizingMask
       viewController!.view.frame = viewController!.evo_visibleDrawerFrame
+      viewController!.view.autoresizingMask = autoResizingMask
+      viewController!.didMove(toParentViewController: self)
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue with top layout guide or safe area.

First sample shows that safe area is ignored for left side controller (tableview's top is pinned to safe area):
![without_fix](https://user-images.githubusercontent.com/7339487/33242279-309d2842-d2e3-11e7-86c1-218c0a285e95.gif)

Second sample shows the correct behavior (with 20px indent for status bar):
![with_fix](https://user-images.githubusercontent.com/7339487/33242296-93c7b662-d2e3-11e7-99ec-e6c0824732b6.gif)

Here are the full demo project: [TestDrawerController.zip](https://github.com/sascha/DrawerController/files/1504064/TestDrawerController.zip)
I've left comments in Podfile to easily switch between my fork and latest released DrawerController pod.